### PR TITLE
File icons via nvim-web-devicons

### DIFF
--- a/lua/buffers/formatters.lua
+++ b/lua/buffers/formatters.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local devicons_loaded, devicons = pcall(require, "nvim-web-devicons")
+
 ---@alias formatter fun(full_path: string): string, integer[]|nil returns formatted string and hl range
 
 ---range is end-exclusive path name without the tail
@@ -7,6 +9,16 @@ local M = {}
 function M.relative_path(full_path)
 	local rel_path = vim.fn.fnamemodify(full_path, ":~:.")
 	local dir_name = vim.fn.fnamemodify(rel_path, ":h")
+	if devicons_loaded and vim.g.buffers_config.icon then
+		local icon, _ = devicons.get_icon(
+			vim.fn.fnamemodify(full_path, ":t"),
+			vim.fn.fnamemodify(full_path, ":e"),
+			{ default = true }
+		)
+		if icon then
+			rel_path = icon .. " " .. rel_path
+		end
+	end
 	if dir_name == "." then
 		return rel_path
 	end
@@ -18,6 +30,16 @@ end
 function M.filename_first(full_path)
 	local file_name = vim.fn.fnamemodify(full_path, ":t")
 	local dir_name = vim.fn.fnamemodify(full_path, ":~:.:h")
+	if devicons_loaded and vim.g.buffers_config.icon then
+		local icon, _ = devicons.get_icon(
+			vim.fn.fnamemodify(full_path, ":t"),
+			vim.fn.fnamemodify(full_path, ":e"),
+			{ default = true }
+		)
+		if icon then
+			file_name = icon .. " " .. file_name
+		end
+	end
 	if dir_name == "." then
 		return file_name
 	end

--- a/lua/buffers/init.lua
+++ b/lua/buffers/init.lua
@@ -10,6 +10,7 @@
 ---@field close_keys? string[] which keys will hide buffers window, without warning, when pressed
 ---@field separator? string separator between char and buffer name
 ---@field formatter? 'relative_path'|'filename_first'|formatter how to format buffer name
+---@field icon? boolean whether to show icon or not
 
 local M = {}
 
@@ -41,6 +42,7 @@ local function with_defaults(opts)
 		close_keys = opts.close_keys or { "<Esc>" },
 		separator = opts.separator or " | ",
 		formatter = opts.formatter or "relative_path",
+		icon = opts.icon or false,
 	}
 end
 


### PR DESCRIPTION
This PR includes:
- Change to the default formatters to have an icon next to the filename. This relies on nvim-web-devicons (https://github.com/nvim-tree/nvim-web-devicons).
- The formatter checks for:
   1. If the devicons plugin is loaded;
   2. Global vim.g.buffers_config.icon is set to true.
   If both of those are true, an icon is appended to the filename.

The code is based on code from reach.nvim (https://github.com/toppair/reach.nvim)